### PR TITLE
Add authorization checking to SSE server

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -103,6 +103,11 @@ def main() -> None:
         default=[],
         help="Allowed origins for the SSE server. Can be used multiple times. Default is no CORS allowed.",  # noqa: E501
     )
+    sse_server_group.add_argument(
+        "--auth-token",
+        help="Authorization token required for SSE server access",
+        type=str,
+    )
 
     args = parser.parse_args()
 
@@ -143,6 +148,7 @@ def main() -> None:
         bind_host=args.sse_host,
         port=args.sse_port,
         allow_origins=args.allow_origin if len(args.allow_origin) > 0 else None,
+        auth_token=args.auth_token,
     )
     asyncio.run(run_sse_server(stdio_params, sse_settings))
 

--- a/src/mcp_proxy/sse_server.py
+++ b/src/mcp_proxy/sse_server.py
@@ -12,6 +12,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.routing import Mount, Route
 
 from .proxy_server import create_proxy_server
@@ -25,6 +26,7 @@ class SseServerSettings:
     port: int
     allow_origins: list[str] | None = None
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    auth_token: str | None = None  # Add this line
 
 
 def create_starlette_app(
@@ -32,6 +34,7 @@ def create_starlette_app(
     *,
     allow_origins: list[str] | None = None,
     debug: bool = False,
+    auth_token: str | None = None,  # Add this parameter
 ) -> Starlette:
     """Create a Starlette application that can server the provied mcp server with SSE."""
     sse = SseServerTransport("/messages/")
@@ -58,6 +61,34 @@ def create_starlette_app(
                 allow_headers=["*"],
             ),
         )
+
+    # Add authentication middleware
+    @app.middleware("http")
+    async def auth_middleware(request, call_next):
+        # Skip auth check if no token is configured
+        if auth_token is None:
+            return await call_next(request)
+            
+        # Get the authorization header
+        auth_header = request.headers.get("Authorization")
+        
+        # Check if header exists and matches expected format
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return Response(
+                "Unauthorized: Missing or invalid Authorization header",
+                status_code=401
+            )
+            
+        # Extract and validate the token
+        token = auth_header.replace("Bearer ", "")
+        if token != auth_token:
+            return Response(
+                "Unauthorized: Invalid token",
+                status_code=401
+            )
+            
+        # If we get here, auth is successful
+        return await call_next(request)
 
     return Starlette(
         debug=debug,
@@ -88,6 +119,7 @@ async def run_sse_server(
             mcp_server,
             allow_origins=sse_settings.allow_origins,
             debug=(sse_settings.log_level == "DEBUG"),
+            auth_token=sse_settings.auth_token,  # Pass the auth_token parameter
         )
 
         # Configure HTTP server


### PR DESCRIPTION
Add authorization checking to SSE server.

* **sse_server.py**
  - Add `auth_token` parameter to `SseServerSettings` class.
  - Add middleware in `create_starlette_app` function to validate the authorization header against the configured token.
  - Reject unauthorized requests with a 401 status code before they reach the stdio server.
  - Pass the `auth_token` parameter to the `create_starlette_app` function.

* **__main__.py**
  - Add a new command-line argument `--auth-token` to accept the authorization token parameter.
  - Pass the `auth_token` parameter to the `SseServerSettings` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DeanoC/mcp-proxy/pull/1?shareId=2a3da5c4-9821-4416-90eb-1e3f00d20973).